### PR TITLE
refactor/예약 현황의 시간 박스의 '지남'상태를 현재 시간을 기준으로 적용되게끔 변경

### DIFF
--- a/client/src/lib/data.ts
+++ b/client/src/lib/data.ts
@@ -227,14 +227,16 @@ export const EV_STATIONS: ChargingStation[] = [
 export function generateTimeSlots(stationId: string): TimeSlot[] {
   const now = new Date();
   const currentHour = now.getHours();
-  
+
   // Seed-based pseudo-random for consistent demo data per station
   const seed = stationId.charCodeAt(stationId.length - 1);
-  
+
   return Array.from({ length: 24 }, (_, i) => {
-    if (i < currentHour - 1) return { hour: i, status: "past" };
-    if (i === currentHour - 1 || i === currentHour) return { hour: i, status: "occupied" };
-    
+    // 현재 시간보다 이전의 모든 시간은 '지남'으로 표시
+    if (i < currentHour) return { hour: i, status: "past" };
+    // 현재 시간은 예약 불가 처리 (진행 중)
+    if (i === currentHour) return { hour: i, status: "occupied" };
+
     // Pseudo-random based on hour + seed
     const rand = ((i * 7 + seed * 13) % 10) / 10;
     if (rand < 0.3) return { hour: i, status: "occupied" };


### PR DESCRIPTION
<img width="397" height="370" alt="Screenshot 2026-02-25 at 15 05 30" src="https://github.com/user-attachments/assets/5cb2f551-cb7d-444f-ac5e-657748d6c681" />

- 사진 속 `지난` 상태 적용 기준을 현재시간으로 변경.
- 분 단위로 상태 동기화 하게끔 수정.
